### PR TITLE
updateUnit() in DB.php #49Mel

### DIFF
--- a/api/application/Application.php
+++ b/api/application/Application.php
@@ -178,9 +178,9 @@ class Application {
     public function updateUnits($params) {
         $userId = $this->user->getUser($params['token']);
         if ($userId) {
-            $gamerId = $this->gamer->getGamer($userId);
-            if ($gamerId) {
-                $time = $this->gamer->updateUnits($gamerId, $params['units']);
+            $gamer = $this->gamer->getGamer($userId);
+            if ($gamer) {
+                $time = $this->gamer->updateUnits($params['units']);
                 if ($time) {
                     $this->game->updateMap($time);
                 }

--- a/api/application/db/DB.php
+++ b/api/application/db/DB.php
@@ -265,6 +265,15 @@ class DB {
         return $this->getArray($query);
     }
 
+    // По id отдельного юнита меняет у него любое property в БД
+    public function updateUnit($unitId, $prop, $value){
+        $query = '
+            UPDATE units
+            SET '. $prop .'='. $value.'
+            WHERE id=' .$unitId;
+        $this->db->query($query);
+        return true;
+    }
 
     ////////////////////////////////////////
     //////////////forGamers/////////////////

--- a/api/application/gamer/Gamer.php
+++ b/api/application/gamer/Gamer.php
@@ -84,8 +84,11 @@
             return $this->db->getGamer($user);
         }
 
-        public function updateUnits($gamerId, $unitsStr) {
-            // $this->db->updateUnits($gamerId, $unitsStr);
+        public function updateUnits($unitsStr) {
+            // foreach unit
+            // $this->db->updateUnit($unitId, $prop, $value);
+            // }
+
             $this->db->setUnitsHash(md5(rand()));
             $statuses = $this->db->getStatuses();
             $time = microtime();
@@ -93,5 +96,15 @@
                 $this->db->setMapTimeStamp($time);
                 return $time;
             }
+        }
+
+        public function healUnit($unitId){
+            // #53 Miro
+            // $this->db->updateUnit($unitId, $prop, 100);
+        }
+
+        public function damageUnit($unitId){
+            // #54 Miro
+            // $this->db->updateUnit(...);
         }
     }


### PR DESCRIPTION
**Замечание: меняет значения только на числовые (не строковые)**

Покидал несколько запросов из Gamer.php:
`$this->db->updateUnit(40, 'hp', 44);`
`$this->db->updateUnit(40, 'posX', 44);`
`$this->db->updateUnit(40, 'posY', 455);`
`$this->db->updateUnit(40, 'status', 3);`
`$this->db->updateUnit(40, 'direction', 33);`

Результат на скриншоте:
https://drive.google.com/file/d/1QlZBm0gLeHCPSBce_djjNcngXktWrUII/view?usp=sharing